### PR TITLE
Added Entry to FAQ for Docker on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ SDKs or APIs available.  The general workflow would look something like: webhook
 
 You can use the `tvwb.py shell` command to open a python shell with the app context.  This allows you to interact with the app without having to enter `python3 tvwb.py` every time.
 
+#### Running Docker on Windows?
+
+If you are using Docker on Windows, open the `docker-compose.yml` file and either remove the line `network_mode: 'host'` or change `host` to `bridge` (default when `network_mode` is not provided).
+The `host` network mode does not work with Windows and will cause the connection to the container to never complete. You will also need to add the `publish` parameter to the docker command such as: `docker-compose -dp 5000:5000 run app`.
+
 #### How do I get more help?
 
 At the moment, the wiki is under construction.  However, you may still find some good info on there.  For additional assistance you can DM me on [Twitter](https://twitter.com/robswc) or join the [Discord](https://discord.gg/wrjuSaZCFh).  I will try my best to get back to you!


### PR DESCRIPTION
The default configuration of the `docker-compose.yml` file does not run on Windows. The solution is to change `network_mode` from `host` to `bridge` and use the --publish or -p parameter to bind the port.